### PR TITLE
Fix: Handle invalid desktop files gracefully and prevent duplicate entries

### DIFF
--- a/nautilus-extension/Flickernaut/manager.py
+++ b/nautilus-extension/Flickernaut/manager.py
@@ -126,18 +126,24 @@ class ApplicationConfigLoader:
                 for k, v in schemaKey.items():
                     logger.debug(f"{k}: {v!r}")
 
-                application = Application(
-                    schemaKey["id"],
-                    schemaKey["app_id"],
-                    schemaKey["name"],
-                    schemaKey["pinned"],
-                    schemaKey["multiple_files"],
-                    schemaKey["multiple_folders"],
-                )
+                try:
+                    application = Application(
+                        schemaKey["id"],
+                        schemaKey["app_id"],
+                        schemaKey["name"],
+                        schemaKey["pinned"],
+                        schemaKey["multiple_files"],
+                        schemaKey["multiple_folders"],
+                    )
 
-                logger.debug("")
+                    logger.debug("")
 
-                registry.add_application(application)
+                    registry.add_application(application)
+                except Exception as e:
+                    logger.warning(
+                        f"Skipping invalid application '{schemaKey.get('name', 'unknown')}': {e}"
+                    )
+                    continue
 
             return registry
 

--- a/nautilus-extension/Flickernaut/models.py
+++ b/nautilus-extension/Flickernaut/models.py
@@ -31,7 +31,13 @@ class Package:
 
     def __init__(self, app_id: str):
         self.app_id = app_id
-        self.app_info = Gio.DesktopAppInfo.new(app_id) if app_id else None
+        try:
+            self.app_info = Gio.DesktopAppInfo.new(app_id) if app_id else None
+            if app_id and not self.app_info:
+                logger.warning(f"Desktop file not found: {app_id}")
+        except Exception as e:
+            logger.error(f"Error loading desktop file '{app_id}': {e}")
+            self.app_info = None
         self._is_installed_cache = None
 
     @property

--- a/src/prefs/application.ts
+++ b/src/prefs/application.ts
@@ -22,7 +22,7 @@ const AppDialog = GObject.registerClass(
             });
 
             this.get_widget().set({
-                show_all: true,
+                show_all: false,
                 show_other: true,
             });
 


### PR DESCRIPTION
This commit addresses two critical bugs in Flickernaut and fixes the issue that I opened https://github.com/imoize/flickernaut/issues/10:

1. Extension crash with invalid desktop files (Critical)
   - Added try-except error handling in Package.__init__ to gracefully handle NULL returns from Gio.DesktopAppInfo.new()
   - Wrapped Application creation in try-except in manager.py to skip invalid applications during initialisation instead of crashing
   - Prevents complete extension failure when a configured app's desktop file doesn't exist

2. Duplicate entries in the preferences app chooser
   - Changed show_all from true to false in AppDialog (application.ts)
   - This respects the NoDisplay=true setting in URL handler desktop files
   - Prevents apps like Positron and Antigravity from appearing twice (once for the main app, once for the URL handler)

Files modified:
- nautilus-extension/Flickernaut/models.py: Error handling for NULL desktop files
- nautilus-extension/Flickernaut/manager.py: Skip invalid apps during init
- src/prefs/application.ts: Respect NoDisplay=true setting

Fixes: Extension crashes, preventing all context menus from appearing
Fixes: Duplicate application entries in preferences dialogue